### PR TITLE
feat : 카카오 로그인 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,11 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
+    implementation 'io.jsonwebtoken:jjwt:0.9.1'
+    implementation group: 'javax.xml.bind', name: 'jaxb-api', version: '2.1'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/plate/silverplate/config/SecurityConfig.java
+++ b/src/main/java/com/plate/silverplate/config/SecurityConfig.java
@@ -1,15 +1,58 @@
 package com.plate.silverplate.config;
 
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
+import java.util.List;
+
+@RequiredArgsConstructor
+@EnableWebSecurity
 @Configuration
 public class SecurityConfig {
-
+    @Value("${cors.allowed-origins}")
+    String[] corsOrigins;
 
     @Bean
-    public WebSecurityCustomizer webSecurityCustomizer() {
-        return (web) -> web.ignoring().anyRequest();
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        return http
+                .cors(corsConfig -> corsConfig.configurationSource(configurationSource()))
+                .csrf(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .sessionManagement(sessionManagementConfig ->
+                        sessionManagementConfig.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                )
+                .authorizeHttpRequests(authorizeRequests ->
+                        authorizeRequests
+                                .requestMatchers("/**").permitAll()
+                )
+                .build();
+    }
+
+    @Bean
+    public CorsConfigurationSource configurationSource() {
+        // TODO: 나중에 클라이언트 주소만 허용할 예정
+        CorsConfiguration configuration = new CorsConfiguration();
+
+        configuration.setAllowedOriginPatterns(List.of(corsOrigins));
+        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE"));
+        configuration.setAllowedHeaders(List.of("*"));
+        configuration.setExposedHeaders(List.of("Access-Control-Allow-Credentials", "Authorization", "Set_Cookie"));
+        configuration.setAllowCredentials(true);
+        configuration.setMaxAge(3600L);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+
+        return source;
     }
 }

--- a/src/main/java/com/plate/silverplate/user/controller/OauthController.java
+++ b/src/main/java/com/plate/silverplate/user/controller/OauthController.java
@@ -1,0 +1,25 @@
+package com.plate.silverplate.user.controller;
+
+import com.plate.silverplate.user.domain.dto.LoginResponse;
+import com.plate.silverplate.user.service.OauthService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RequiredArgsConstructor
+@RestController
+public class OauthController {
+    private final OauthService oauthService;
+
+    @GetMapping("/login/oauth/{provider}")
+    public ResponseEntity<LoginResponse> login(@PathVariable String provider, @RequestParam String code) {
+        LoginResponse loginResponse = oauthService.login(provider, code);
+
+        return ResponseEntity.ok().body(loginResponse);
+    }
+}

--- a/src/main/java/com/plate/silverplate/user/domain/dto/KakaoUserInfo.java
+++ b/src/main/java/com/plate/silverplate/user/domain/dto/KakaoUserInfo.java
@@ -1,0 +1,44 @@
+package com.plate.silverplate.user.domain.dto;
+
+import java.util.Map;
+
+public class KakaoUserInfo implements Oauth2UserInfo {
+    private Map<String, Object> attributes;
+
+    public KakaoUserInfo(Map<String, Object> attributes) {
+        this.attributes = attributes;
+    }
+
+    @Override
+    public String getProviderId() {
+        return String.valueOf(attributes.get("id"));
+    }
+
+    @Override
+    public String getProvider() {
+        return "kakao";
+    }
+
+    @Override
+    public String getEmail() {
+        return (String) getKakaoAccount().get("email");
+    }
+
+    @Override
+    public String getNickName() {
+        return (String) getProfile().get("nickname");
+    }
+
+    @Override
+    public String getImageUrl() {
+        return (String)getProfile().get("profile_image_url");
+    }
+
+    public Map<String, Object> getKakaoAccount(){
+        return(Map<String, Object>) attributes.get("kakao_account");
+    }
+
+    public Map<String, Object> getProfile(){
+        return (Map<String, Object>) getKakaoAccount().get("profile");
+    }
+}

--- a/src/main/java/com/plate/silverplate/user/domain/dto/LoginResponse.java
+++ b/src/main/java/com/plate/silverplate/user/domain/dto/LoginResponse.java
@@ -1,0 +1,29 @@
+package com.plate.silverplate.user.domain.dto;
+
+import com.plate.silverplate.user.domain.entity.Role;
+import lombok.*;
+
+@Getter
+@NoArgsConstructor
+public class LoginResponse {
+    private Long id;
+    private String nickName;
+    private String email;
+    private String imageUrl;
+    private Role role;
+    private String tokenType;
+    private String accessToken;
+    private String refreshToken;
+
+    @Builder
+    public LoginResponse(Long id, String nickName, String email, String imageUrl, Role role, String tokenType, String accessToken, String refreshToken) {
+        this.id = id;
+        this.nickName = nickName;
+        this.email = email;
+        this.imageUrl = imageUrl;
+        this.role = role;
+        this.tokenType = tokenType;
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+    }
+}

--- a/src/main/java/com/plate/silverplate/user/domain/dto/Oauth2UserInfo.java
+++ b/src/main/java/com/plate/silverplate/user/domain/dto/Oauth2UserInfo.java
@@ -1,0 +1,9 @@
+package com.plate.silverplate.user.domain.dto;
+
+public interface Oauth2UserInfo {
+    String getProvider();
+    String getNickName();
+    String getEmail();
+    String getProviderId();
+    String getImageUrl();
+}

--- a/src/main/java/com/plate/silverplate/user/domain/dto/OauthTokenResponse.java
+++ b/src/main/java/com/plate/silverplate/user/domain/dto/OauthTokenResponse.java
@@ -1,0 +1,17 @@
+package com.plate.silverplate.user.domain.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@NoArgsConstructor
+@Getter
+@Setter
+public class OauthTokenResponse {
+    private String access_token;
+    private String token_type;
+    private String refresh_token;
+    private int expires_in;
+    private String scope;
+    private int refresh_token_expires_in;
+}

--- a/src/main/java/com/plate/silverplate/user/domain/entity/Role.java
+++ b/src/main/java/com/plate/silverplate/user/domain/entity/Role.java
@@ -1,0 +1,16 @@
+package com.plate.silverplate.user.domain.entity;
+
+public enum Role {
+    GUEST("ROLE_GUEST"),
+    USER("ROLE_USER");
+
+    private final String key;
+
+    Role(String key) {
+        this.key = key;
+    }
+
+    public String getKey() {
+        return key;
+    }
+}

--- a/src/main/java/com/plate/silverplate/user/domain/entity/User.java
+++ b/src/main/java/com/plate/silverplate/user/domain/entity/User.java
@@ -8,7 +8,7 @@ import jakarta.validation.constraints.Size;
 import lombok.*;
 
 @Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor
 @Entity
 @Table(name = "user")
 public class User extends BaseTimeEntity {
@@ -19,48 +19,44 @@ public class User extends BaseTimeEntity {
 
     @Size(max = 30)
     @NotNull
-    @Column(name = "password", nullable = false, length = 30)
-    private String password;
-
-    @Size(max = 20)
-    @NotNull
-    @Column(name = "username", nullable = false, length = 20)
-    private String username;
-
-    @Size(max = 30)
-    @NotNull
-    @Column(name = "email", nullable = false, length = 30)
+    @Column(name = "email", nullable = false, unique = true)
     private String email;
 
-    @Size(max = 20)
     @NotNull
-    @Column(name = "role", nullable = false, length = 20)
-    private String role;
+    @Column(name = "role", nullable = false)
+    private Role role;
 
-    @Size(max = 40)
-    @NotNull
-    @Column(name = "provideId", nullable = false, length = 40)
-    private String provideId;
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    @JoinColumn(name = "user_profile_id")
+    private UserProfile userProfile;
 
-    @Size(max = 40)
-    @NotNull
-    @Column(name = "provider", nullable = false, length = 40)
-    private String provider;
-
-    @NotNull
-    @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "user_physcal_id", nullable = false)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_physcal_id")
     private UserPhysical userPhysical;
 
     @Builder
-    public User(Long id, String password, String username, String email, String role, String provideId, String provider, UserPhysical userPhysical) {
+    public User(Long id, String email, Role role, UserProfile userProfile, UserPhysical userPhysical) {
         this.id = id;
-        this.password = password;
-        this.username = username;
         this.email = email;
         this.role = role;
-        this.provideId = provideId;
-        this.provider = provider;
+        this.userProfile = userProfile;
         this.userPhysical = userPhysical;
+    }
+
+    public static User createUser(String email, String nickName, String provider, String providerId, String imageUrl) {
+        UserProfile profile = UserProfile.createProfile(nickName, provider, providerId, imageUrl);
+
+        User user = User.builder()
+                .email(email)
+                .role(Role.USER)
+                .build();
+
+        user.addUserProfile(profile);
+
+        return user;
+    }
+
+    private void addUserProfile(UserProfile profile) {
+        this.userProfile = profile;
     }
 }

--- a/src/main/java/com/plate/silverplate/user/domain/entity/UserProfile.java
+++ b/src/main/java/com/plate/silverplate/user/domain/entity/UserProfile.java
@@ -1,0 +1,58 @@
+package com.plate.silverplate.user.domain.entity;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class UserProfile {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @Column(name = "nickName", nullable = false)
+    private String nickName;
+
+    @OneToOne(mappedBy = "userProfile", fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_profile_id")
+    private User user;
+
+    @Column(name = "image_url", nullable = false)
+    private String imageUrl;
+
+    @Size(max = 40)
+    @NotNull
+    @Column(name = "provider_id", nullable = false, length = 40)
+    private String providerId;
+
+    @Size(max = 40)
+    @NotNull
+    @Column(name = "provider", nullable = false, length = 40)
+    private String provider;
+
+    @Builder
+    public UserProfile(Long id, String nickName, User user, String imageUrl, String providerId, String provider) {
+        this.id = id;
+        this.nickName = nickName;
+        this.user = user;
+        this.imageUrl = imageUrl;
+        this.providerId = providerId;
+        this.provider = provider;
+    }
+
+    public static UserProfile createProfile(String nickName, String provider, String providerId, String imageUrl) {
+        return UserProfile.builder()
+                .nickName(nickName)
+                .provider(provider)
+                .providerId(providerId)
+                .imageUrl(imageUrl)
+                .build();
+    }
+}

--- a/src/main/java/com/plate/silverplate/user/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/plate/silverplate/user/jwt/JwtTokenProvider.java
@@ -1,0 +1,72 @@
+package com.plate.silverplate.user.jwt;
+
+import io.jsonwebtoken.*;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import java.util.Random;
+
+@Component
+@Slf4j
+public class JwtTokenProvider {
+
+    @Value("${jwt.access-token.expire-length}")
+    private long accessTokenValidityInMilliseconds;
+
+    @Value("${jwt.refresh-token.expire-length}")
+    private long refreshTokenValidityInMilliseconds;
+
+    @Value("${jwt.token.secret-key}")
+    private String secretKey;
+
+    public String createAccessToken(String payload) {
+        return createToken(payload, accessTokenValidityInMilliseconds);
+    }
+
+    public String createRefreshToken() {
+        byte[] array = new byte[7];
+        new Random().nextBytes(array);
+        String generatedString = new String(array, StandardCharsets.UTF_8);
+        return createToken(generatedString, refreshTokenValidityInMilliseconds);
+    }
+
+    public String createToken(String payload, long expireLength) {
+        Claims claims = Jwts.claims().setSubject(payload);
+        Date now = new Date();
+        Date validity = new Date(now.getTime() + expireLength);
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(now)
+                .setExpiration(validity)
+                .signWith(SignatureAlgorithm.HS256,secretKey)
+                .compact();
+    }
+
+    public String getPayload(String token){
+        try {
+            return Jwts.parser()
+                    .setSigningKey(secretKey)
+                    .parseClaimsJws(token)
+                    .getBody()
+                    .getSubject();
+        } catch (ExpiredJwtException e) {
+            return e.getClaims().getSubject();
+        } catch (JwtException e){
+            throw new RuntimeException("유효하지 않은 토큰 입니다");
+        }
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Jws<Claims> claimsJws = Jwts.parser()
+                    .setSigningKey(secretKey)
+                    .parseClaimsJws(token);
+            return !claimsJws.getBody().getExpiration().before(new Date());
+        } catch (JwtException | IllegalArgumentException exception) {
+            return false;
+        }
+    }
+}

--- a/src/main/java/com/plate/silverplate/user/repository/UserRepository.java
+++ b/src/main/java/com/plate/silverplate/user/repository/UserRepository.java
@@ -1,0 +1,8 @@
+package com.plate.silverplate.user.repository;
+
+import com.plate.silverplate.user.domain.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    User findByEmail(String email);
+}

--- a/src/main/java/com/plate/silverplate/user/service/OauthService.java
+++ b/src/main/java/com/plate/silverplate/user/service/OauthService.java
@@ -1,0 +1,128 @@
+package com.plate.silverplate.user.service;
+
+import com.plate.silverplate.user.domain.dto.KakaoUserInfo;
+import com.plate.silverplate.user.domain.dto.LoginResponse;
+import com.plate.silverplate.user.domain.dto.Oauth2UserInfo;
+import com.plate.silverplate.user.domain.dto.OauthTokenResponse;
+import com.plate.silverplate.user.domain.entity.User;
+import com.plate.silverplate.user.jwt.JwtTokenProvider;
+import com.plate.silverplate.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.MediaType;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.Map;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class OauthService {
+    private static String BEARER_TYPE = "Bearer";
+    private final InMemoryClientRegistrationRepository inMemoryRepository;
+    private final UserRepository userRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    /**
+     * @InMemoryRepository application-oauth properties 정보를 담고 있음
+     * @getToken() 넘겨받은 code로 Oauth 서버에 Token 요청
+     * @getUserProfile 첫 로그인 시 회원가입
+     * 유저 인증 후 Jwt AccessToken, Refresh Token 생성
+     * TODO: REDIS에 Refresh Token 저장
+     */
+
+    @Transactional
+    public LoginResponse login(String providerName, String code) {
+        ClientRegistration provider = inMemoryRepository.findByRegistrationId(providerName);
+        OauthTokenResponse tokenResponse = getToken(code, provider);
+        User user = getUserProfile(providerName, tokenResponse, provider);
+
+        String accessToken = jwtTokenProvider.createAccessToken(String.valueOf(user.getId()));
+        String refreshToken = jwtTokenProvider.createRefreshToken();
+
+        return LoginResponse.builder()
+                .id(user.getId())
+                .nickName(user.getUserProfile().getNickName())
+                .email(user.getEmail())
+                .imageUrl(user.getUserProfile().getImageUrl())
+                .role(user.getRole())
+                .tokenType(BEARER_TYPE)
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+
+    private OauthTokenResponse getToken(String code, ClientRegistration provider) {
+        return WebClient.create()
+                    .post()
+                    .uri(provider.getProviderDetails().getTokenUri())
+                    .headers(header -> {
+                        header.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+                        header.setAcceptCharset(Collections.singletonList(StandardCharsets.UTF_8));
+                    })
+                    .bodyValue(tokenRequest(code, provider))
+                    .retrieve()
+                    .bodyToMono(OauthTokenResponse.class)
+                    .block();
+    }
+
+    private MultiValueMap<String, String> tokenRequest(String code, ClientRegistration provider) {
+        MultiValueMap<String, String > formData = new LinkedMultiValueMap<>();
+
+        formData.add("code", code);
+        formData.add("grant_type", "authorization_code");
+        formData.add("redirect_uri", provider.getRedirectUri());
+        formData.add("client_secret", provider.getClientSecret());
+        formData.add("client_id", provider.getClientId());
+
+        return formData;
+    }
+
+    private User getUserProfile(String providerName, OauthTokenResponse tokenResponse, ClientRegistration provider) {
+
+        Map<String, Object> userAttributes = getUserAttributes(provider, tokenResponse);
+        Oauth2UserInfo oauth2UserInfo = null;
+
+        if (providerName.equals("kakao")) {
+            oauth2UserInfo = new KakaoUserInfo(userAttributes);
+        } else {
+            log.info("허용되지 않은 접근 입니다.");
+        }
+
+        String provide = oauth2UserInfo.getProvider();
+        String providerId = oauth2UserInfo.getProviderId();
+        String nickName = oauth2UserInfo.getNickName();
+        String email = oauth2UserInfo.getEmail();
+        String imageUrl = oauth2UserInfo.getImageUrl();
+
+        User userEntity = userRepository.findByEmail(email);
+
+        if (userEntity == null) {
+            userEntity = User.createUser(email, nickName, provide, providerId, imageUrl);
+            userRepository.save(userEntity);
+        }
+
+        return userEntity;
+    }
+
+    private Map<String, Object> getUserAttributes(ClientRegistration provider, OauthTokenResponse tokenResponse) {
+        return WebClient.create()
+                .get()
+                .uri(provider.getProviderDetails().getUserInfoEndpoint().getUri())
+                .headers(header -> header.setBearerAuth(tokenResponse.getAccess_token()))
+                .retrieve()
+                .bodyToMono(new ParameterizedTypeReference<Map<String, Object>>() {})
+                .block();
+    }
+}
+
+

--- a/src/main/resources/application-oauth.yml
+++ b/src/main/resources/application-oauth.yml
@@ -1,0 +1,22 @@
+spring:
+  security:
+    oauth2:
+      client:
+        registration:
+          kakao:
+            client-id: ${KAKAO_CLIENT_ID}
+            redirect-uri: ${KAKAO_REDIRECT_URI}
+            client-authentication-method: POST
+            client-secret: ${KAKAO_CLIENT_SECRET}
+            authorization-grant-type: authorization_code
+            scope:
+              - profile_nickname
+              - profile_image
+              - account_email
+            client_name: kakao
+        provider:
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,8 +16,31 @@ spring:
         format_sql: true
         use_sql_comments: true
     defer-datasource-initialization: true
+  profiles:
+    include: oauth
 
+jwt:
+  token:
+    secret-key: ${JWT_SECRET}
+  access-token:
+    expire-length: 1800000
+  refresh-token:
+    expire-length: 1209600000
 
+redis:
+  host: localhost
+  port: 6379
 
+logging:
+  level:
+    org:
+      hibernate:
+        type: trace
+        stat: debug
+        orm:
+          jdbc:
+            bind: trace
+    org.springframework.web.reactive.function.client.ExchangeFunctions: TRACE
 
-
+cors:
+  allowed-origins: "*"


### PR DESCRIPTION
## 작업 내용 
- 카카오 소셜 로그인 간단 구현 (Authorization Grant Code 방식 사용)
## 작업 설명
- oauth 관련 설정 추가
- User entity에서 UserProfile 분리
- login에 사용되는 request, response dto 추가
- client에게 전달할 jwt token provider 추가
- kakao login 구현
## 요구되는 추후 작업
- jwt 토큰 redis 저장
- security context에 어떤 값을 넣을지 JwtTokenProvider 수정
- 비즈니스 로직 리팩토링

