### PR TITLE
feat: SuccessHandler 응답 데이터 형식 변경

### DIFF
--- a/src/main/java/com/plate/silverplate/common/exception/MyAuthenticationSuccessHandler.java
+++ b/src/main/java/com/plate/silverplate/common/exception/MyAuthenticationSuccessHandler.java
@@ -1,22 +1,19 @@
 package com.plate.silverplate.common.exception;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.plate.silverplate.user.domain.dto.GeneratedToken;
-import com.plate.silverplate.user.domain.dto.LoginResponse;
 import com.plate.silverplate.user.jwt.utill.JwtUtil;
-import com.plate.silverplate.user.service.OauthService;
-import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 @Slf4j
 @Component
@@ -24,11 +21,9 @@ import java.io.IOException;
 public class MyAuthenticationSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
     private final JwtUtil jwtUtil;
-    private final OauthService oauthService;
 
     @Override
-    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
-
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException {
         // 인증된 사용자 정보
         OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
         String email = oAuth2User.getAttribute("email");
@@ -43,36 +38,31 @@ public class MyAuthenticationSuccessHandler extends SimpleUrlAuthenticationSucce
         // 토큰 생성
         GeneratedToken token = jwtUtil.generateToken(email, role);
 
-        ObjectMapper objectMapper = new ObjectMapper();
-
         if (isExist) {
-            LoginResponse tokenResponse = LoginResponse.builder()
-                    .accessToken(token.getAccessToken())
-                    .refreshToken(token.getRefreshToken())
-                    .firstLogin(false)
-                    .build();
-            String jsonBody = objectMapper.writeValueAsString(tokenResponse);
+            String targetUrl = UriComponentsBuilder.fromUriString("http://localhost:3000/loginSuccess")
+                    .queryParam("access_token", token.getAccessToken())
+                    .build()
+                    .encode(StandardCharsets.UTF_8)
+                    .toUriString();
 
-            // resonse 설정
-            response.setContentType("application/json;charset=UTF-8");
-            response.setStatus(HttpStatus.OK.value());
-            response.getWriter().write(jsonBody);
-            response.getWriter().flush();
+            response.addHeader("Authorization", token.getRefreshToken());
 
+            log.info("redirect : {}", targetUrl);
+
+            getRedirectStrategy().sendRedirect(request, response, targetUrl);
         } else {
-            oauthService.save(oAuth2User);      // 회원 가입
+            String targetUrl = UriComponentsBuilder.fromUriString("http://localhost:3000/signUp")
+                    .queryParam("access_token", token.getAccessToken())
+                    .queryParam("refresh_token", token.getRefreshToken())
+                    .build()
+                    .encode(StandardCharsets.UTF_8)
+                    .toUriString();
 
-            LoginResponse tokenResponse = LoginResponse.builder()
-                    .accessToken(token.getAccessToken())
-                    .firstLogin(true)
-                    .build();
-            String jsonBody = objectMapper.writeValueAsString(tokenResponse);
+            response.addHeader("Authorization", token.getRefreshToken());
 
-            // resonse 설정
-            response.setContentType("application/json;charset=UTF-8");
-            response.setStatus(HttpStatus.OK.value());
-            response.getWriter().write(jsonBody);
-            response.getWriter().flush();
+            log.info("redirect : {}", targetUrl);
+
+            getRedirectStrategy().sendRedirect(request, response, targetUrl);
         }
     }
 }

--- a/src/main/java/com/plate/silverplate/common/exception/MyAuthenticationSuccessHandler.java
+++ b/src/main/java/com/plate/silverplate/common/exception/MyAuthenticationSuccessHandler.java
@@ -48,20 +48,17 @@ public class MyAuthenticationSuccessHandler extends SimpleUrlAuthenticationSucce
     }
 
     private String buildTargetUrl(boolean isExist, String accessToken) {
-        String baseUrl = "http://localhost:3000/";
+        String baseUrl = "http://localhost:3000/users/login";
+        UriComponentsBuilder urlBuilder = UriComponentsBuilder.fromUriString(baseUrl)
+                .queryParam("access_token", accessToken).encode(StandardCharsets.UTF_8);
 
         if (isExist) {
-            return UriComponentsBuilder.fromUriString(baseUrl + "login/success")
-                    .queryParam("access_token", accessToken)
+            return urlBuilder.queryParam("is_first","false")
                     .build()
-                    .encode(StandardCharsets.UTF_8)
-                    .toUriString();
-        } else {
-            return UriComponentsBuilder.fromUriString(baseUrl + "signup")
-                    .queryParam("access_token", accessToken)
-                    .build()
-                    .encode(StandardCharsets.UTF_8)
                     .toUriString();
         }
+        return urlBuilder.queryParam("is_first","true")
+                .build()
+                .toUriString();
     }
 }

--- a/src/main/java/com/plate/silverplate/common/exception/MyAuthenticationSuccessHandler.java
+++ b/src/main/java/com/plate/silverplate/common/exception/MyAuthenticationSuccessHandler.java
@@ -53,7 +53,6 @@ public class MyAuthenticationSuccessHandler extends SimpleUrlAuthenticationSucce
         } else {
             String targetUrl = UriComponentsBuilder.fromUriString("http://localhost:3000/signUp")
                     .queryParam("access_token", token.getAccessToken())
-                    .queryParam("refresh_token", token.getRefreshToken())
                     .build()
                     .encode(StandardCharsets.UTF_8)
                     .toUriString();

--- a/src/main/java/com/plate/silverplate/user/domain/entity/UserProfile.java
+++ b/src/main/java/com/plate/silverplate/user/domain/entity/UserProfile.java
@@ -1,5 +1,6 @@
 package com.plate.silverplate.user.domain.entity;
 
+import com.plate.silverplate.common.entity.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -9,7 +10,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity(name = "user_profile")
-public class UserProfile {
+public class UserProfile extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id", nullable = false)

--- a/src/main/java/com/plate/silverplate/user/jwt/fillter/JwtAuthFilter.java
+++ b/src/main/java/com/plate/silverplate/user/jwt/fillter/JwtAuthFilter.java
@@ -5,7 +5,6 @@ import com.plate.silverplate.common.exception.ErrorException;
 import com.plate.silverplate.user.domain.entity.User;
 import com.plate.silverplate.user.jwt.utill.JwtUtil;
 import com.plate.silverplate.user.repository.UserRepository;
-import io.jsonwebtoken.JwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -42,11 +41,6 @@ public class JwtAuthFilter extends OncePerRequestFilter {
         if (!StringUtils.hasText(accessToken)) {
             doFilter(request, response, filterChain);
             return;
-        }
-
-        // AccessToken 만료 여부 확인
-        if (!jwtUtil.verifyToken(accessToken)) {
-            throw new JwtException("만료된 Access Token입니다.");
         }
 
         if (jwtUtil.verifyToken(accessToken)) {

--- a/src/main/java/com/plate/silverplate/user/jwt/utill/JwtUtil.java
+++ b/src/main/java/com/plate/silverplate/user/jwt/utill/JwtUtil.java
@@ -2,10 +2,7 @@ package com.plate.silverplate.user.jwt.utill;
 
 import com.plate.silverplate.user.domain.dto.GeneratedToken;
 import com.plate.silverplate.user.service.RedisService;
-import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.Jws;
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.*;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -87,10 +84,16 @@ public class JwtUtil {
             return claims.getBody()
                     .getExpiration()
                     .after(new Date());  // 만료 시간이 현재 시간 이후인지 확인하여 유효성 검사 결과를 반환
-        } catch (Exception e) {
-            log.error(e.getMessage());
-            return false;
-        }
+            } catch (MalformedJwtException e) {
+                log.info("Invalid JWT Token", e);
+            } catch (ExpiredJwtException e) {
+                log.info("Expired JWT Token", e);
+            } catch (UnsupportedJwtException e) {
+                log.info("Unsupported JWT Token", e);
+            } catch (IllegalArgumentException e) {
+                log.info("JWT claims string is empty.", e);
+            }
+        return false;
     }
 
     // 토큰에서 email 추출

--- a/src/main/java/com/plate/silverplate/user/jwt/utill/JwtUtil.java
+++ b/src/main/java/com/plate/silverplate/user/jwt/utill/JwtUtil.java
@@ -86,14 +86,17 @@ public class JwtUtil {
                     .after(new Date());  // 만료 시간이 현재 시간 이후인지 확인하여 유효성 검사 결과를 반환
             } catch (MalformedJwtException e) {
                 log.info("Invalid JWT Token", e);
+                throw new JwtException("Invalid JWT Token", e);
             } catch (ExpiredJwtException e) {
                 log.info("Expired JWT Token", e);
+                throw new JwtException("Expired JWT Token", e);
             } catch (UnsupportedJwtException e) {
                 log.info("Unsupported JWT Token", e);
+                throw new JwtException("Unsupported JWT Token", e);
             } catch (IllegalArgumentException e) {
                 log.info("JWT claims string is empty.", e);
+                throw new JwtException("JWT claims string is empty.", e);
             }
-        return false;
     }
 
     // 토큰에서 email 추출


### PR DESCRIPTION
## 작업 내용 
- json 형식 응답 → 프론트엔드 url로 redirect하고, query string에 토큰 전달
## 작업 설명
- 로그인이 성공하면 프론트엔드 url로 redirect하고, query string에 access token 전달, Authorization 헤더에 refresh token 전달
- jwt token에서 발생하는 exception을 더 상세하게 로그로 남김
- 사용자에 대한 회원가입, 프로필 갱신을 oauthService에서 처리하도록 변경
- 갱신이 되는 데이터이므로, 사용자 프로필에도 jpa auditing 추가

