### PR TITLE
feat: 신체 정보 수정, 기존 정보 조회 api

### DIFF
--- a/src/main/java/com/plate/silverplate/common/exception/ErrorCode.java
+++ b/src/main/java/com/plate/silverplate/common/exception/ErrorCode.java
@@ -10,8 +10,9 @@ public enum ErrorCode {
     JSON_NOT_PROCESSING(HttpStatus.BAD_REQUEST,"서버 내부적인 JSON 에러"),
     NON_EXISTENT_LIST_DTO(HttpStatus.BAD_REQUEST, "List DTO가 존재하지 않습니다."),
     UNAUTHORIZED_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "권한없는 Refresh Token입니다."),
-    NON_EXISTENT_EMAIL(HttpStatus.BAD_REQUEST, "해당 EMAIL의 사용자가 존재하지 않습니다."),
-    NOT_FOUND_NUTRITION_FACT(HttpStatus.NOT_FOUND,"음식 영양정보를 찾을 수 없습니다.");
+    NON_EXISTENT_EMAIL(HttpStatus.NOT_FOUND, "해당 EMAIL의 사용자가 존재하지 않습니다."),
+    NOT_FOUND_NUTRITION_FACT(HttpStatus.NOT_FOUND,"음식 영양정보를 찾을 수 없습니다."),
+    NON_EXISTENT_USER(HttpStatus.NOT_FOUND, "해당 사용자의 신체 정보가 존재하지 않습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/plate/silverplate/user/domain/entity/User.java
+++ b/src/main/java/com/plate/silverplate/user/domain/entity/User.java
@@ -1,11 +1,12 @@
 package com.plate.silverplate.user.domain.entity;
 
 import com.plate.silverplate.common.entity.BaseTimeEntity;
-import com.plate.silverplate.userPhysical.domain.entity.UserPhysical;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
-import lombok.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
@@ -30,17 +31,12 @@ public class User extends BaseTimeEntity {
     @JoinColumn(name = "user_profile_id")
     private UserProfile userProfile;
 
-    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
-    @JoinColumn(name = "user_physcal_id")
-    private UserPhysical userPhysical;
-
     @Builder
-    public User(Long id, String email, String role, UserProfile userProfile, UserPhysical userPhysical) {
+    public User(Long id, String email, String role, UserProfile userProfile) {
         this.id = id;
         this.email = email;
         this.role = role;
         this.userProfile = userProfile;
-        this.userPhysical = userPhysical;
     }
 
     public static User createUser(String email, String nickName, String provider, String imageUrl) {
@@ -62,9 +58,5 @@ public class User extends BaseTimeEntity {
 
     public void updateUserProfile(UserProfile profile) {
         this.userProfile = profile;
-    }
-
-    public void updateUserPhysical(UserPhysical userPhysical) {
-        this.userPhysical = userPhysical;
     }
 }

--- a/src/main/java/com/plate/silverplate/userPhysical/controller/UserPhysicalController.java
+++ b/src/main/java/com/plate/silverplate/userPhysical/controller/UserPhysicalController.java
@@ -1,16 +1,16 @@
 package com.plate.silverplate.userPhysical.controller;
 
 import com.plate.silverplate.user.domain.entity.User;
-import com.plate.silverplate.userPhysical.domain.dto.UserPhysicalRequest;
+import com.plate.silverplate.userPhysical.domain.dto.request.UserPhysicalRequest;
+import com.plate.silverplate.userPhysical.domain.dto.response.UserPhysicalCreateResponse;
+import com.plate.silverplate.userPhysical.domain.dto.response.UserPhysicalResponse;
+import com.plate.silverplate.userPhysical.domain.entity.UserPhysical;
 import com.plate.silverplate.userPhysical.service.UserPhysicalService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RequestMapping("/api/v1/userPhysicals")
 @RequiredArgsConstructor
@@ -19,9 +19,24 @@ public class UserPhysicalController {
     private final UserPhysicalService userPhysicalService;
 
     @PostMapping("")
-    public ResponseEntity<String> createUserPhysical(@AuthenticationPrincipal User user,
+    public ResponseEntity<UserPhysicalCreateResponse> createUserPhysical(@AuthenticationPrincipal User user,
                                                      @Valid @RequestBody UserPhysicalRequest physicalRequest) {
-        Long createdId = userPhysicalService.createUserPhysical(physicalRequest, user);
-        return ResponseEntity.ok("Created User Physical Id: " + createdId);
+        UserPhysical userPhysical = userPhysicalService.createUserPhysical(physicalRequest, user);
+        return ResponseEntity.ok(UserPhysicalCreateResponse.of(userPhysical));
+    }
+
+    @GetMapping("")
+    public ResponseEntity<UserPhysicalResponse> getUserPhysical(@AuthenticationPrincipal User user) {
+        UserPhysical userPhysical = userPhysicalService.getUserPhysical(user);
+
+        return ResponseEntity.ok(UserPhysicalResponse.of(userPhysical));
+    }
+
+    @PatchMapping("")
+    public ResponseEntity<UserPhysicalResponse> updateUserPhysical(@AuthenticationPrincipal User user,
+                                                                   @Valid @RequestBody UserPhysicalRequest physicalRequest) {
+        UserPhysical userPhysical = userPhysicalService.updateUserPhysical(physicalRequest, user);
+
+        return ResponseEntity.ok(UserPhysicalResponse.of(userPhysical));
     }
 }

--- a/src/main/java/com/plate/silverplate/userPhysical/domain/dto/request/UserPhysicalRequest.java
+++ b/src/main/java/com/plate/silverplate/userPhysical/domain/dto/request/UserPhysicalRequest.java
@@ -1,4 +1,4 @@
-package com.plate.silverplate.userPhysical.domain.dto;
+package com.plate.silverplate.userPhysical.domain.dto.request;
 
 import com.plate.silverplate.userPhysical.domain.entity.Gender;
 import jakarta.validation.constraints.*;

--- a/src/main/java/com/plate/silverplate/userPhysical/domain/dto/response/UserPhysicalCreateResponse.java
+++ b/src/main/java/com/plate/silverplate/userPhysical/domain/dto/response/UserPhysicalCreateResponse.java
@@ -1,0 +1,11 @@
+package com.plate.silverplate.userPhysical.domain.dto.response;
+
+import com.plate.silverplate.userPhysical.domain.entity.UserPhysical;
+
+public record UserPhysicalCreateResponse(
+        Long userPhysicalId
+) {
+    public static UserPhysicalCreateResponse of(UserPhysical userPhysical){
+        return new UserPhysicalCreateResponse(userPhysical.getId());
+    }
+}

--- a/src/main/java/com/plate/silverplate/userPhysical/domain/dto/response/UserPhysicalResponse.java
+++ b/src/main/java/com/plate/silverplate/userPhysical/domain/dto/response/UserPhysicalResponse.java
@@ -1,0 +1,26 @@
+package com.plate.silverplate.userPhysical.domain.dto.response;
+
+import com.plate.silverplate.userPhysical.domain.entity.Gender;
+import com.plate.silverplate.userPhysical.domain.entity.UserPhysical;
+import lombok.Builder;
+
+@Builder
+public record UserPhysicalResponse(
+        Long id,
+        Gender gender,
+        float height,
+        float weight,
+        int age,
+        int activityCoefficient
+) {
+    public static UserPhysicalResponse of(UserPhysical userPhysical) {
+        return UserPhysicalResponse.builder()
+                .id(userPhysical.getId())
+                .gender(userPhysical.getGender())
+                .height(userPhysical.getHeight())
+                .weight(userPhysical.getWeight())
+                .age(userPhysical.getAge())
+                .activityCoefficient(userPhysical.getActivityCoefficient())
+                .build();
+    }
+}

--- a/src/main/java/com/plate/silverplate/userPhysical/domain/entity/UserPhysical.java
+++ b/src/main/java/com/plate/silverplate/userPhysical/domain/entity/UserPhysical.java
@@ -1,6 +1,8 @@
 package com.plate.silverplate.userPhysical.domain.entity;
 
 import com.plate.silverplate.common.entity.BaseTimeEntity;
+import com.plate.silverplate.user.domain.entity.User;
+import com.plate.silverplate.userPhysical.domain.dto.request.UserPhysicalRequest;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -33,13 +35,26 @@ public class UserPhysical extends BaseTimeEntity {
     @Column(name = "activity_coefficient", nullable = false)
     private int activityCoefficient;
 
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
     @Builder
-    public UserPhysical(Long id, Gender gender, float height, float weight, int age, int activityCoefficient) {
+    public UserPhysical(Long id, Gender gender, float height, float weight, int age, int activityCoefficient, User user) {
         this.id = id;
         this.gender = gender;
         this.height = height;
         this.weight = weight;
         this.age = age;
         this.activityCoefficient = activityCoefficient;
+        this.user = user;
+    }
+
+    public void updatePhysicalInfo(UserPhysicalRequest physicalRequest) {
+        this.gender = physicalRequest.gender();
+        this.height = physicalRequest.height();
+        this.weight = physicalRequest.weight();
+        this.age = physicalRequest.age();
+        this.activityCoefficient = physicalRequest.activityCoefficient();
     }
 }

--- a/src/main/java/com/plate/silverplate/userPhysical/repository/UserPhysicalRepository.java
+++ b/src/main/java/com/plate/silverplate/userPhysical/repository/UserPhysicalRepository.java
@@ -1,7 +1,11 @@
 package com.plate.silverplate.userPhysical.repository;
 
+import com.plate.silverplate.user.domain.entity.User;
 import com.plate.silverplate.userPhysical.domain.entity.UserPhysical;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserPhysicalRepository extends JpaRepository<UserPhysical, Long> {
+    Optional<UserPhysical> findUserPhysicalByUser(User user);
 }

--- a/src/main/java/com/plate/silverplate/userPhysical/service/UserPhysicalService.java
+++ b/src/main/java/com/plate/silverplate/userPhysical/service/UserPhysicalService.java
@@ -1,8 +1,9 @@
 package com.plate.silverplate.userPhysical.service;
 
+import com.plate.silverplate.common.exception.ErrorCode;
+import com.plate.silverplate.common.exception.ErrorException;
 import com.plate.silverplate.user.domain.entity.User;
-import com.plate.silverplate.user.repository.UserRepository;
-import com.plate.silverplate.userPhysical.domain.dto.UserPhysicalRequest;
+import com.plate.silverplate.userPhysical.domain.dto.request.UserPhysicalRequest;
 import com.plate.silverplate.userPhysical.domain.entity.UserPhysical;
 import com.plate.silverplate.userPhysical.repository.UserPhysicalRepository;
 import lombok.RequiredArgsConstructor;
@@ -13,23 +14,38 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class UserPhysicalService {
     private final UserPhysicalRepository userPhysicalRepository;
-    private final UserRepository userRepository;
 
     @Transactional
-    public Long createUserPhysical(UserPhysicalRequest physicalRequest, User user) {
+    public UserPhysical createUserPhysical(UserPhysicalRequest physicalRequest, User user) {
         UserPhysical userPhysical = UserPhysical.builder()
                 .gender(physicalRequest.gender())
                 .weight(physicalRequest.weight())
                 .height(physicalRequest.height())
                 .age(physicalRequest.age())
                 .activityCoefficient(physicalRequest.activityCoefficient())
+                .user(user)
                 .build();
 
-        UserPhysical createdUserPhysical = userPhysicalRepository.save(userPhysical);
+        return userPhysicalRepository.save(userPhysical);
+    }
 
-        user.updateUserPhysical(createdUserPhysical);
-        userRepository.save(user);
+    @Transactional(readOnly = true)
+    public UserPhysical getUserPhysical(User user) {
+        return findByUser(user);
+    }
 
-        return createdUserPhysical.getId();
+    @Transactional
+    public UserPhysical updateUserPhysical(UserPhysicalRequest physicalRequest, User user) {
+        UserPhysical userPhysical = findByUser(user);
+
+        userPhysical.updatePhysicalInfo(physicalRequest);
+
+        return userPhysical;
+    }
+
+    @Transactional(readOnly = true)
+    public UserPhysical findByUser(User user) {
+        return userPhysicalRepository.findUserPhysicalByUser(user)
+                .orElseThrow(() -> new ErrorException(ErrorCode.NON_EXISTENT_USER));
     }
 }


### PR DESCRIPTION
## 작업 내용 
- 수정 페이지에 사용할 기존 정보 조회와 수정 api 구현
## 작업 설명
- 로그인 유저 정보를 통해 신체 정보에 접근하는 쪽이 많아 연관관계의 주인을 변경
- 신체정보 조회, 수정 api 추가
- 신체 정보 생성 시, string 응답값 → dto 응답값으로 변경
## 결과
- 조회
![image](https://github.com/silver-plate/SilverPlate-BE/assets/63100425/594eb48f-93f0-4b44-ac91-2bb8155e0a05)
- 수정
![image](https://github.com/silver-plate/SilverPlate-BE/assets/63100425/a0ee350b-3f71-448e-b3af-a0f13ebb1cdd)
